### PR TITLE
Fix: Correct RTSP URL channel numbering

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -101,8 +101,8 @@
 //
 // Get streaming URLs for RTSP, RTMP, or FLV:
 //
-//	// RTSP URL for main stream
-//	rtspURL := client.Streaming.GetRTSPURL(reolink.StreamMain, 1)
+//	// RTSP URL for main stream (channel 0)
+//	rtspURL := client.Streaming.GetRTSPURL(reolink.StreamMain, 0)
 //	fmt.Printf("RTSP: %s\n", rtspURL)
 //
 //	// RTMP URL for sub stream

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -84,8 +84,8 @@ func main() {
 
 	// Get streaming URLs
 	fmt.Println("\nStreaming URLs:")
-	fmt.Printf("RTSP Main: %s\n", client.Streaming.GetRTSPURL(reolink.StreamMain, 1))
-	fmt.Printf("RTSP Sub:  %s\n", client.Streaming.GetRTSPURL(reolink.StreamSub, 1))
+	fmt.Printf("RTSP Main: %s\n", client.Streaming.GetRTSPURL(reolink.StreamMain, 0))
+	fmt.Printf("RTSP Sub:  %s\n", client.Streaming.GetRTSPURL(reolink.StreamSub, 0))
 	fmt.Printf("RTMP Main: %s\n", client.Streaming.GetRTMPURL(reolink.StreamMain, 0))
 	fmt.Printf("FLV Main:  %s\n", client.Streaming.GetFLVURL(reolink.StreamMain, 0))
 

--- a/examples/hardware_test/main.go
+++ b/examples/hardware_test/main.go
@@ -159,8 +159,8 @@ func main() {
 	// Test 9: Streaming URLs
 	fmt.Println("\n--- Test 9: Streaming URLs ---")
 	fmt.Println("✅ Generated Streaming URLs:")
-	fmt.Printf("   RTSP Main:     %s\n", client.Streaming.GetRTSPURL(reolink.StreamMain, 1))
-	fmt.Printf("   RTSP Sub:      %s\n", client.Streaming.GetRTSPURL(reolink.StreamSub, 1))
+	fmt.Printf("   RTSP Main:     %s\n", client.Streaming.GetRTSPURL(reolink.StreamMain, 0))
+	fmt.Printf("   RTSP Sub:      %s\n", client.Streaming.GetRTSPURL(reolink.StreamSub, 0))
 	fmt.Printf("   RTMP Main:     %s\n", client.Streaming.GetRTMPURL(reolink.StreamMain, 0))
 	fmt.Printf("   FLV Main:      %s\n", client.Streaming.GetFLVURL(reolink.StreamMain, 0))
 

--- a/streaming.go
+++ b/streaming.go
@@ -11,11 +11,12 @@ type StreamingAPI struct {
 
 // GetRTSPURL generates an RTSP URL for the specified stream type and channel
 //
-// Channel numbers start from 1 for RTSP URLs (e.g., 1, 2, 3)
+// The channel parameter is 0-based (e.g., 0, 1, 2) and will be converted to
+// the 1-based channel numbers used in RTSP URLs (e.g., 01, 02, 03).
 //
 // Example:
 //
-//	url := client.Streaming.GetRTSPURL(reolink.StreamMain, 1)
+//	url := client.Streaming.GetRTSPURL(reolink.StreamMain, 0)
 //	// rtsp://admin:password@192.168.1.100:554/Preview_01_main
 func (s *StreamingAPI) GetRTSPURL(streamType StreamType, channel int) string {
 	s.client.logger.Debug("generating RTSP URL: stream=%s channel=%d", streamType, channel)
@@ -24,7 +25,8 @@ func (s *StreamingAPI) GetRTSPURL(streamType StreamType, channel int) string {
 	port := 554
 
 	// Format channel with leading zero (01, 02, etc.)
-	channelStr := fmt.Sprintf("%02d", channel)
+	// RTSP uses 1-based channel numbers, so add 1 to the 0-based channel parameter
+	channelStr := fmt.Sprintf("%02d", channel+1)
 
 	// Build URL with credentials
 	var url string

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -14,22 +14,28 @@ func TestStreamingAPI_GetRTSPURL(t *testing.T) {
 		expected   string
 	}{
 		{
-			name:       "Main stream channel 1",
-			channel:    1,
+			name:       "Main stream channel 0",
+			channel:    0,
 			streamType: StreamMain,
 			expected:   "rtsp://admin:password@192.168.1.100:554/Preview_01_main",
 		},
 		{
-			name:       "Sub stream channel 1",
-			channel:    1,
+			name:       "Sub stream channel 0",
+			channel:    0,
 			streamType: StreamSub,
 			expected:   "rtsp://admin:password@192.168.1.100:554/Preview_01_sub",
 		},
 		{
-			name:       "Main stream channel 2",
-			channel:    2,
+			name:       "Main stream channel 1",
+			channel:    1,
 			streamType: StreamMain,
 			expected:   "rtsp://admin:password@192.168.1.100:554/Preview_02_main",
+		},
+		{
+			name:       "Ext stream channel 2",
+			channel:    2,
+			streamType: StreamExt,
+			expected:   "rtsp://admin:password@192.168.1.100:554/Preview_03_ext",
 		},
 	}
 


### PR DESCRIPTION
## Summary
Fixes #2 - Incorrect RTSP URL generation for camera streams

## Problem
The SDK was generating RTSP URLs with incorrect channel numbers:
- SDK generated: `rtsp://admin:password@192.168.49.206:554/Preview_00_main` (for channel 0)
- Camera expects: `rtsp://192.168.49.206:554/Preview_01_main` (for channel 0)

## Root Cause
The Reolink API uses 0-based channel numbers (0, 1, 2...) but RTSP URLs use 1-based channel numbers (01, 02, 03...). The SDK was not converting between these numbering schemes.

## Solution
- Modified `GetRTSPURL()` to add 1 to the channel parameter when constructing URLs
- Updated documentation to clarify that the channel parameter is 0-based
- Updated all examples to use channel 0 instead of channel 1
- Added test coverage for ExtStream type

## Testing
- ✅ All unit tests pass
- ✅ Verified against real camera hardware (RLC-811WA at 192.168.49.206)
- ✅ Confirmed RTSP stream connects successfully with ffmpeg
- ✅ Pre-commit checks pass (formatting, linting, tests)

## Changes
- `streaming.go`: Fixed channel numbering (`channel+1`)
- `streaming_test.go`: Updated tests to use 0-based channels
- `doc.go`: Updated documentation example
- `examples/basic/main.go`: Updated to use channel 0
- `examples/hardware_test/main.go`: Updated to use channel 0

## Breaking Changes
⚠️ **Potential breaking change**: Users who were passing channel 1 to get the first camera will now need to pass channel 0. However, the old behavior was incorrect according to the API documentation, so this is a bug fix rather than a breaking change.

## References
- Issue #2
- Reolink API Documentation (section 2.7.1 - RTSP mode preview)
- Tested on: RLC-811WA firmware